### PR TITLE
update(examples/k8s_audit_config): Use stable apiVersion audit.k8s.io/v1 for Policy

### DIFF
--- a/examples/k8s_audit_config/audit-policy.yaml
+++ b/examples/k8s_audit_config/audit-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: audit.k8s.io/v1beta1 # This is required.
+apiVersion: audit.k8s.io/v1 # This is required.
 kind: Policy
 # Don't generate audit events for all requests in RequestReceived stage.
 omitStages:


### PR DESCRIPTION
Update the ApiVersion of Policy to `audit.k8s.io/v1` because `audit.k8s.io/v1beta` in newer Kubernetes versions no longer available.

Signed-off-by: Frank Jogeleit <frank.jogeleit@lovoo.com>