### PR TITLE
update(integrations/logdna): update grpc output socket name

### DIFF
--- a/integrations/falco-phoenix-sidecar/sidecar.py
+++ b/integrations/falco-phoenix-sidecar/sidecar.py
@@ -60,7 +60,7 @@ def add_annotation_to_pod(pod_name, namespace, event_name):
 max_num_of_events = os.environ.get('MAXIMUM_NUMBER_OF_EVENTS', "5")
 annotation_key = os.environ.get('ANNOTATION_KEY', "phoenix.r6security.com/falcoevent")
 logging.basicConfig(level=logging.INFO)
-falco_client = falco.Client(endpoint="unix:///var/run/falco/falco.sock",
+falco_client = falco.Client(endpoint="unix:///run/falco/falco.sock",
                             client_crt="/tmp/client.crt",
                             client_key="/tmp/client.key",
                             ca_root="/tmp/ca.crt")

--- a/integrations/logdna/Readme.md
+++ b/integrations/logdna/Readme.md
@@ -18,7 +18,7 @@ Install falco. Configure it to output events over grpc unix socket.
 
 ```
 # # (as root)
-# chmod 777 /var/run/falco.sock 
+# chmod 777 /run/falco/falco.sock
 ```
 
 Get a LogDNA injestion api key.

--- a/integrations/logdna/falco-logdna.py
+++ b/integrations/logdna/falco-logdna.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
     log.addHandler(test)
 
     c = falco.Client(
-        endpoint="unix:///var/run/falco.sock",
+        endpoint="unix:///run/falco/falco.sock",
         output_format=args.output_format,
     )
 


### PR DESCRIPTION
The default grpc unix socket path was changed in 0.33.0 from /var/run/falco.sock to /run/falco/falco.sock and there were still some stale references to the old socket name.